### PR TITLE
Ensure service stops when app dismissed

### DIFF
--- a/app/src/main/java/com/example/wristlingo/TranslatorService.kt
+++ b/app/src/main/java/com/example/wristlingo/TranslatorService.kt
@@ -64,6 +64,7 @@ class TranslatorService : Service() {
     runningJob?.cancel()
     wear.stop()
     tts?.shutdown()
+    stopForeground(STOP_FOREGROUND_REMOVE)
     super.onDestroy()
   }
 
@@ -119,7 +120,12 @@ class TranslatorService : Service() {
         return START_NOT_STICKY
       }
     }
-    return START_STICKY
+    return START_NOT_STICKY
+  }
+
+  override fun onTaskRemoved(rootIntent: Intent?) {
+    stopSimulation()
+    super.onTaskRemoved(rootIntent)
   }
 
   private fun startWork() {


### PR DESCRIPTION
## Summary
- Make `TranslatorService` non-sticky
- Stop simulation when the task is removed
- Release foreground notification in `onDestroy`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4661bd814832a9da8aedb1d477cde