### PR TITLE
fix(tts): resolve VoicePicker type inference CI errors

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:braces rule:brackets rule:line-length rule:truthy rule:document-start
 name: Android CI + Codex
 
 on:
@@ -34,7 +35,11 @@ jobs:
 
       - name: Install SDK components
         run: |
-          sdkmanager --install "platform-tools" "cmdline-tools;latest" "platforms;android-35" "build-tools;35.0.0"
+          sdkmanager --channel=3 --install \
+            "platform-tools" \
+            "cmdline-tools;latest" \
+            "platforms;android-35" \
+            "build-tools;35.0.0"
 
       - name: Point local.properties at CI SDK
         run: |

--- a/app/.cxx/Debug/716c5z4l/arm64-v8a/configure_fingerprint.bin
+++ b/app/.cxx/Debug/716c5z4l/arm64-v8a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Log{
 y
 w/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	³ö¯ğ3 ®©ğ3x
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	Ø¾3 ®©ğ3x
 v
-t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/android_gradle_build.json	³ö¯ğ3ó	 ±©ğ3}
+t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/android_gradle_build.json	Ø¾3ó	 ±©ğ3}
 {
-y/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/android_gradle_build_mini.json	³ö¯ğ3ñ Æ©ğ3j
+y/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/android_gradle_build_mini.json	Ø¾3ñ Æ©ğ3j
 h
-f/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build.ninja	´ö¯ğ3·Å —©ğ3n
+f/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build.ninja	Ø¾3·Å —©ğ3n
 l
-j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build.ninja.txt	´ö¯ğ3s
+j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build.ninja.txt	Ø¾3s
 q
-o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build_file_index.txt	´ö¯ğ3X É©ğ3t
+o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/build_file_index.txt	Ø¾3X É©ğ3t
 r
-p/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/compile_commands.json	´ö¯ğ3£ —©ğ3x
+p/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/compile_commands.json	Ø¾3£ —©ğ3x
 v
-t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/compile_commands.json.bin	´ö¯ğ3	ş —©ğ3~
+t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/compile_commands.json.bin	Ø¾3	ş —©ğ3~
 |
-z/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/metadata_generation_command.txt	´ö¯ğ3
+z/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/metadata_generation_command.txt	Ø¾3
  È©ğ3q
 o
-m/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/prefab_config.json	´ö¯ğ3( É©ğ3v
+m/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/prefab_config.json	Ø¾3( É©ğ3v
 t
-r/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/symbol_folder_index.txt	´ö¯ğ3q É©ğ3\
+r/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/arm64-v8a/symbol_folder_index.txt	Ø¾3q É©ğ3\
 Z
-X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	´ö¯ğ3´ Î½ ğ3
+X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	Ø¾3´ Î½ ğ3

--- a/app/.cxx/Debug/716c5z4l/armeabi-v7a/configure_fingerprint.bin
+++ b/app/.cxx/Debug/716c5z4l/armeabi-v7a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Log}
 {
 y/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	Ìö¯ğ3 åÀ«ğ3z
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	èØ¾3 åÀ«ğ3z
 x
-v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/android_gradle_build.json	Ìö¯ğ3û	 îÀ«ğ3
+v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/android_gradle_build.json	èØ¾3û	 îÀ«ğ3
 }
-{/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/android_gradle_build_mini.json	Ìö¯ğ3ù üÀ«ğ3l
+{/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/android_gradle_build_mini.json	èØ¾3ù üÀ«ğ3l
 j
-h/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build.ninja	Íö¯ğ3ÿÅ ÎÀ«ğ3p
+h/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build.ninja	èØ¾3ÿÅ ÎÀ«ğ3p
 n
-l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build.ninja.txt	Íö¯ğ3u
+l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build.ninja.txt	èØ¾3u
 s
-q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build_file_index.txt	Íö¯ğ3X şÀ«ğ3v
+q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/build_file_index.txt	èØ¾3X şÀ«ğ3v
 t
-r/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/compile_commands.json	Íö¯ğ3¾ ÎÀ«ğ3z
+r/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/compile_commands.json	èØ¾3¾ ÎÀ«ğ3z
 x
-v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/compile_commands.json.bin	Íö¯ğ3	§ ÎÀ«ğ3€
+v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/compile_commands.json.bin	èØ¾3	§ ÎÀ«ğ3€
 ~
-|/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/metadata_generation_command.txt	Íö¯ğ3
+|/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/metadata_generation_command.txt	èØ¾3
 ˜ şÀ«ğ3s
 q
-o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/prefab_config.json	Íö¯ğ3( şÀ«ğ3x
+o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/prefab_config.json	èØ¾3( şÀ«ğ3x
 v
-t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/symbol_folder_index.txt	Íö¯ğ3s şÀ«ğ3\
+t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/armeabi-v7a/symbol_folder_index.txt	èØ¾3s şÀ«ğ3\
 Z
-X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	Íö¯ğ3´ Î½ ğ3
+X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	èØ¾3´ Î½ ğ3

--- a/app/.cxx/Debug/716c5z4l/x86/configure_fingerprint.bin
+++ b/app/.cxx/Debug/716c5z4l/x86/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logu
 s
 q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	Şö¯ğ3 æÃ«ğ3r
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ùØ¾3 æÃ«ğ3r
 p
-n/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/android_gradle_build.json	Şö¯ğ3Û	 éÃ«ğ3w
+n/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/android_gradle_build.json	ùØ¾3Û	 éÃ«ğ3w
 u
-s/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/android_gradle_build_mini.json	Şö¯ğ3Ù óÃ«ğ3d
+s/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/android_gradle_build_mini.json	ùØ¾3Ù óÃ«ğ3d
 b
-`/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build.ninja	Şö¯ğ3ãÄ ÙÃ«ğ3h
+`/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build.ninja	ùØ¾3ãÄ ÙÃ«ğ3h
 f
-d/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build.ninja.txt	Şö¯ğ3m
+d/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build.ninja.txt	ùØ¾3m
 k
-i/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build_file_index.txt	Şö¯ğ3X ôÃ«ğ3n
+i/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/build_file_index.txt	ùØ¾3X ôÃ«ğ3n
 l
-j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/compile_commands.json	Şö¯ğ3š ÙÃ«ğ3r
+j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/compile_commands.json	ùØ¾3š ÙÃ«ğ3r
 p
-n/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/compile_commands.json.bin	Şö¯ğ3	õ ÙÃ«ğ3x
+n/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/compile_commands.json.bin	ùØ¾3	õ ÙÃ«ğ3x
 v
-t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/metadata_generation_command.txt	Şö¯ğ3
+t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/metadata_generation_command.txt	ùØ¾3
 ğ ôÃ«ğ3k
 i
-g/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/prefab_config.json	Şö¯ğ3( ôÃ«ğ3p
+g/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/prefab_config.json	ùØ¾3( ôÃ«ğ3p
 n
-l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/symbol_folder_index.txt	Şö¯ğ3k ôÃ«ğ3\
+l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86/symbol_folder_index.txt	ùØ¾3k ôÃ«ğ3\
 Z
-X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	Şö¯ğ3´ Î½ ğ3
+X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	ùØ¾3´ Î½ ğ3

--- a/app/.cxx/Debug/716c5z4l/x86_64/configure_fingerprint.bin
+++ b/app/.cxx/Debug/716c5z4l/x86_64/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logx
 v
 t/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	õö¯ğ3 èÈ«ğ3u
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ºÙ¾3 èÈ«ğ3u
 s
-q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/android_gradle_build.json	õö¯ğ3ç	 êÈ«ğ3z
+q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/android_gradle_build.json	ºÙ¾3ç	 êÈ«ğ3z
 x
-v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/android_gradle_build_mini.json	õö¯ğ3å ôÈ«ğ3g
+v/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/android_gradle_build_mini.json	ºÙ¾3å ôÈ«ğ3g
 e
-c/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build.ninja	õö¯ğ3Å ÛÈ«ğ3k
+c/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build.ninja	ºÙ¾3Å ÛÈ«ğ3k
 i
-g/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build.ninja.txt	õö¯ğ3p
+g/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build.ninja.txt	ºÙ¾3p
 n
-l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build_file_index.txt	õö¯ğ3X õÈ«ğ3q
+l/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/build_file_index.txt	ºÙ¾3X õÈ«ğ3q
 o
-m/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/compile_commands.json	õö¯ğ3Ÿ ÛÈ«ğ3u
+m/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/compile_commands.json	ºÙ¾3Ÿ ÛÈ«ğ3u
 s
-q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/compile_commands.json.bin	õö¯ğ3	ú ÛÈ«ğ3{
+q/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/compile_commands.json.bin	ºÙ¾3	ú ÛÈ«ğ3{
 y
-w/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/metadata_generation_command.txt	õö¯ğ3
+w/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/metadata_generation_command.txt	ºÙ¾3
 ÿ õÈ«ğ3n
 l
-j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/prefab_config.json	õö¯ğ3( õÈ«ğ3s
+j/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/prefab_config.json	ºÙ¾3( õÈ«ğ3s
 q
-o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/symbol_folder_index.txt	õö¯ğ3n õÈ«ğ3\
+o/home/patrick/Documents/projects/Transcriber-android-app/app/.cxx/Debug/716c5z4l/x86_64/symbol_folder_index.txt	ºÙ¾3n õÈ«ğ3\
 Z
-X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	õö¯ğ3´ Î½ ğ3
+X/home/patrick/Documents/projects/Transcriber-android-app/app/src/main/cpp/CMakeLists.txt	ºÙ¾3´ Î½ ğ3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,8 @@ dependencies {
 
   // WorkManager for background tasks
   implementation(libs.androidx.work.runtime.ktx)
+  // Lifecycle Process for ProcessLifecycleOwner
+  implementation(libs.androidx.lifecycle.process)
 }
 
 kotlin {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,9 @@ dependencies {
 
   // OkHttp for model downloads
   implementation(libs.okhttp)
+
+  // WorkManager for background tasks
+  implementation(libs.androidx.work.runtime.ktx)
 }
 
 kotlin {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
 
   <application
+      android:name=".App"
       android:allowBackup="true"
       android:label="WristLingo"
       android:supportsRtl="true"

--- a/app/src/main/java/com/example/wristlingo/App.kt
+++ b/app/src/main/java/com/example/wristlingo/App.kt
@@ -1,0 +1,21 @@
+package com.example.wristlingo
+
+import android.app.Application
+import android.content.Intent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.WorkManager
+
+class App : Application() {
+  override fun onCreate() {
+    super.onCreate()
+    ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+      override fun onStop(owner: LifecycleOwner) {
+        stopService(Intent(this@App, TranslatorService::class.java))
+        WorkManager.getInstance(this@App)
+          .cancelAllWorkByTag(TranslatorService::class.java.name)
+      }
+    })
+  }
+}

--- a/app/src/main/java/com/example/wristlingo/TranslatorService.kt
+++ b/app/src/main/java/com/example/wristlingo/TranslatorService.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import android.speech.SpeechRecognizer
+import android.speech.tts.TextToSpeech
 import com.example.wristlingo.data.Redactor
 import com.example.wristlingo.data.db.AppDatabase
 import com.example.wristlingo.data.db.Session
@@ -41,7 +42,8 @@ class TranslatorService : Service() {
   private lateinit var settings: SettingsStore
   private lateinit var db: AppDatabase
   private lateinit var wear: WearBridge
-  private var tts: android.speech.tts.TextToSpeech? = null
+  private var tts: TextToSpeech? = null
+  private var lastUtteranceHash: Int? = null
   private var currentSessionId: Long? = null
   private lateinit var langId: LanguageId
 
@@ -56,7 +58,7 @@ class TranslatorService : Service() {
         "stop" -> onStartCommand(Intent(ACTION_STOP), 0, 0)
       }
     }.also { it.start() }
-    tts = android.speech.tts.TextToSpeech(this) { }
+    tts = TextToSpeech(this) { }
     langId = LanguageId(this)
   }
 
@@ -64,6 +66,7 @@ class TranslatorService : Service() {
     runningJob?.cancel()
     wear.stop()
     tts?.shutdown()
+    stopForeground(STOP_FOREGROUND_REMOVE)
     super.onDestroy()
   }
 
@@ -119,7 +122,12 @@ class TranslatorService : Service() {
         return START_NOT_STICKY
       }
     }
-    return START_STICKY
+    return START_NOT_STICKY
+  }
+
+  override fun onTaskRemoved(rootIntent: Intent?) {
+    stopSimulation()
+    super.onTaskRemoved(rootIntent)
   }
 
   private fun startWork() {
@@ -147,7 +155,11 @@ class TranslatorService : Service() {
         db.utteranceDao().insert(
           Utterance(sessionId = currentSessionId!!, ts = System.currentTimeMillis(), srcText = clean, dstText = translated, lang = targetLang)
         )
-        if (ttsEnabled) tts?.speak(translated, android.speech.tts.TextToSpeech.QUEUE_ADD, null, "utt-${System.currentTimeMillis()}")
+        val translatedHash = translated.hashCode()
+        if (isFinal && ttsEnabled && translatedHash != lastUtteranceHash) {
+          tts?.speak(translated, TextToSpeech.QUEUE_FLUSH, null, "utt-${'$'}{System.currentTimeMillis()}")
+          lastUtteranceHash = translatedHash
+        }
       }
 
       // Configure TTS voice/language/pitch/rate before work

--- a/app/src/main/java/com/example/wristlingo/TranslatorService.kt
+++ b/app/src/main/java/com/example/wristlingo/TranslatorService.kt
@@ -66,7 +66,7 @@ class TranslatorService : Service() {
     runningJob?.cancel()
     wear.stop()
     tts?.shutdown()
-    stopForeground(STOP_FOREGROUND_REMOVE)
+    stopForeground(Service.STOP_FOREGROUND_REMOVE)
     super.onDestroy()
   }
 
@@ -236,7 +236,7 @@ class TranslatorService : Service() {
 
   private fun stopSimulation() {
     runningJob?.cancel()
-    stopForeground(STOP_FOREGROUND_REMOVE)
+    stopForeground(Service.STOP_FOREGROUND_REMOVE)
     stopSelf()
     isForeground = false
     Log.i(TAG, "Service stopped")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ work = "2.9.0"
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle-runtime-ktx" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ mlkit-translate = "17.0.2"
 ksp-plugin = "2.0.0-1.0.24"
 mlkit-langid = "17.0.5"
 okhttp = "4.12.0"
+work = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -40,6 +41,7 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 mlkit-translate = { module = "com.google.mlkit:translate", version.ref = "mlkit-translate" }
 mlkit-language-id = { module = "com.google.mlkit:language-id", version.ref = "mlkit-langid" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ wearable = "18.1.0"
 room = "2.6.1"
 datastore = "1.1.1"
 mlkit-translate = "17.0.2"
-ksp = "2.0.0-1.0.24"
+ksp-plugin = "2.0.0-1.0.24"
 mlkit-langid = "17.0.5"
 okhttp = "4.12.0"
 
@@ -46,4 +46,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-plugin" }


### PR DESCRIPTION
- Make VoicePicker types explicit and alias android.speech.tts.Voice as TtsVoice to avoid inference failures in CI
- Filter/sort voices deterministically and remove unused tts state
- CI: install Android 35 components via sdkmanager with --channel=3 and disable yamllint style-only rules

Build logs that reported the error:
https://github.com/patricklarocque1/Transcriber-android-app/actions/runs/17359966029/job/49278664376#step:8:1