### PR TITLE
Guard TTS speech and prevent duplicates

### DIFF
--- a/app/src/main/java/com/example/wristlingo/TranslatorService.kt
+++ b/app/src/main/java/com/example/wristlingo/TranslatorService.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import android.speech.SpeechRecognizer
+import android.speech.tts.TextToSpeech
 import com.example.wristlingo.data.Redactor
 import com.example.wristlingo.data.db.AppDatabase
 import com.example.wristlingo.data.db.Session
@@ -41,7 +42,8 @@ class TranslatorService : Service() {
   private lateinit var settings: SettingsStore
   private lateinit var db: AppDatabase
   private lateinit var wear: WearBridge
-  private var tts: android.speech.tts.TextToSpeech? = null
+  private var tts: TextToSpeech? = null
+  private var lastUtteranceHash: Int? = null
   private var currentSessionId: Long? = null
   private lateinit var langId: LanguageId
 
@@ -56,7 +58,7 @@ class TranslatorService : Service() {
         "stop" -> onStartCommand(Intent(ACTION_STOP), 0, 0)
       }
     }.also { it.start() }
-    tts = android.speech.tts.TextToSpeech(this) { }
+    tts = TextToSpeech(this) { }
     langId = LanguageId(this)
   }
 
@@ -147,7 +149,11 @@ class TranslatorService : Service() {
         db.utteranceDao().insert(
           Utterance(sessionId = currentSessionId!!, ts = System.currentTimeMillis(), srcText = clean, dstText = translated, lang = targetLang)
         )
-        if (ttsEnabled) tts?.speak(translated, android.speech.tts.TextToSpeech.QUEUE_ADD, null, "utt-${System.currentTimeMillis()}")
+        val translatedHash = translated.hashCode()
+        if (isFinal && ttsEnabled && translatedHash != lastUtteranceHash) {
+          tts?.speak(translated, TextToSpeech.QUEUE_FLUSH, null, "utt-${'$'}{System.currentTimeMillis()}")
+          lastUtteranceHash = translatedHash
+        }
       }
 
       // Configure TTS voice/language/pitch/rate before work


### PR DESCRIPTION
## Summary
- Only speak translations when they are final and not a repeat
- Flush existing speech instead of queuing for new utterances
- Track last spoken translation hash to avoid duplicates

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4661c5334832aa3554003cbac6e7e