### PR TITLE
Stop audio service on background

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,9 @@ dependencies {
 
   // OkHttp for model downloads
   implementation(libs.okhttp)
+
+  // WorkManager for background tasks
+  implementation(libs.androidx.work.runtime.ktx)
 }
 
 kotlin {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
 
   <application
+      android:name=".App"
       android:allowBackup="true"
       android:label="WristLingo"
       android:supportsRtl="true"

--- a/app/src/main/java/com/example/wristlingo/App.kt
+++ b/app/src/main/java/com/example/wristlingo/App.kt
@@ -1,0 +1,21 @@
+package com.example.wristlingo
+
+import android.app.Application
+import android.content.Intent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.WorkManager
+
+class App : Application() {
+  override fun onCreate() {
+    super.onCreate()
+    ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+      override fun onStop(owner: LifecycleOwner) {
+        stopService(Intent(this@App, TranslatorService::class.java))
+        WorkManager.getInstance(this@App)
+          .cancelAllWorkByTag(TranslatorService::class.java.name)
+      }
+    })
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ mlkit-translate = "17.0.2"
 ksp = "2.0.0-1.0.24"
 mlkit-langid = "17.0.5"
 okhttp = "4.12.0"
+work = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -40,6 +41,7 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 mlkit-translate = { module = "com.google.mlkit:translate", version.ref = "mlkit-translate" }
 mlkit-language-id = { module = "com.google.mlkit:language-id", version.ref = "mlkit-langid" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- register Application subclass and lifecycle observer to stop audio when app backgrounds
- register App in manifest and add WorkManager dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4661e7bb4832aad461f5796774ed3